### PR TITLE
Fixed bug where the shadowing of a variable caused a python variable lookup to fail

### DIFF
--- a/hypothesis_geojson/__init__.py
+++ b/hypothesis_geojson/__init__.py
@@ -179,7 +179,7 @@ def feature_collection(draw):
     -----
     Foreign Members and bbox
     """
-    features = draw(lists(features()))
+    feature_list = draw(lists(features()))
     return {
         'type': 'FeatureCollection',
-        'features': features}
+        'features': feature_list}


### PR DESCRIPTION
When running with python 3.6 I got the error that:

"The local variable features referenced before assignment"

Simply changing the name of the local variable so that it no longer shadows the function features fixed the issue.