### PR TITLE
Remove the possiility of numbers being generated as keys in maps/objects/dictionaries.

### DIFF
--- a/hypothesis_geojson/__init__.py
+++ b/hypothesis_geojson/__init__.py
@@ -139,7 +139,7 @@ def geometry_collection(draw):
 @composite
 def properties(draw):
     return draw(dictionaries(
-        keys=one_of(text(), integers()),
+        keys=text(),
         values=one_of(
             text(),
             integers(),
@@ -163,8 +163,7 @@ def features(draw):
 
     # foreign members
     if draw(booleans()):
-        key = draw(one_of(
-            integers(), text(), floats(allow_nan=False, allow_infinity=False)))
+        key = draw(text())
         value = draw(one_of(
             integers(), text(), none(), floats(allow_nan=False, allow_infinity=False)))
         feature[key] = value


### PR DESCRIPTION
According to the [GeoJSON specification][0]:

> GeoJSON is a format for encoding a variety of geographic data
> structures using JavaScript Object Notation (JSON) [RFC7159]

The GeoJSON specification [RFC7159] in turn specifies that

> An object structure is represented as a pair of curly brackets
> surrounding zero or more name/value pairs (or members).  A name
> is a string.

In other words: In order for this generator to conform to the spec it
cannot produce numbers as the keys/names in objects. And as is noted
in the GeoJSON spec,

> A Feature object has a member with the name "properties".  The value
> of the properties member is an object (any JSON object or a JSON
> null value).

[0]: https://tools.ietf.org/html/rfc7946
[RFC7159]: https://tools.ietf.org/html/rfc7159