### PR TITLE
Fix incorrect import of assume

### DIFF
--- a/hypothesis_geojson/__init__.py
+++ b/hypothesis_geojson/__init__.py
@@ -5,8 +5,9 @@ A hypothesis strategy for generating GeoJSON
 __version__ = '0.1'
 
 
+from hypothesis import assume
 from hypothesis.strategies import (
-    assume, booleans, composite, dictionaries, floats, integers, lists, none,
+    booleans, composite, dictionaries, floats, integers, lists, none,
     one_of, sampled_from, text, tuples)
 
 


### PR DESCRIPTION
The `assume` function is [incorrectly][1] being imported from `hypothesis.strategies` instead of `hypothesis`.

This worked by coincidence in the [version][2] of hypothesis available when hypothesis-geojson was released.  In modern releases of hypothesis, assume is no longer imported into strategies, causing an ImportError which prevents usage of this library.  Since assume was not listed as a member of `__all__`, the import was inappropriate at the time of release anyway.

Correcting the import to the documented location fixes the ImportError.

[1]: https://hypothesis.readthedocs.io/en/latest/details.html#hypothesis.assume
[2]: https://github.com/HypothesisWorks/hypothesis/blob/3.11.6/src/hypothesis/strategies.py#L27